### PR TITLE
Closes #2 ArrayOutOfBound Exceptions verhindern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8

--- a/src/main/java/de/thalia/boot/tracing/rest/TraceRestTemplateCustomizer.java
+++ b/src/main/java/de/thalia/boot/tracing/rest/TraceRestTemplateCustomizer.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
 
-import de.thalia.boot.tracing.TraceLog;
-import de.thalia.boot.tracing.Tracer;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.web.client.RestTemplateCustomizer;
@@ -35,6 +33,8 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 
+import de.thalia.boot.tracing.TraceLog;
+import de.thalia.boot.tracing.Tracer;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -106,7 +106,7 @@ public class TraceRestTemplateCustomizer implements RestTemplateCustomizer {
         // Wir versuchen deshalb, den Namen aus dem Stack-Trace zu erraten
         String theGuessedName = "unknown";
         StackTraceElement[] theCurrentTrace = Thread.currentThread().getStackTrace();
-        for (int i=0; i<= theCurrentTrace.length; i++) {
+        for (int i = 0; i < theCurrentTrace.length; i++) {
             StackTraceElement theElement = theCurrentTrace[i];
             String theDefiningClass = theElement.getClassName();
             int p = theDefiningClass.lastIndexOf(".");

--- a/src/test/java/org/thalia/boot/tracing/rest/TraceRestTemplateCustomizerTest.java
+++ b/src/test/java/org/thalia/boot/tracing/rest/TraceRestTemplateCustomizerTest.java
@@ -1,0 +1,42 @@
+/*
+ * (c) Copyright 2019 Thalia Bücher GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thalia.boot.tracing.rest;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+import org.springframework.web.client.RestTemplate;
+
+import de.thalia.boot.tracing.rest.TraceRestTemplateCustomizer;
+
+/**
+ * Tests für {@link TraceRestTemplateCustomizer}
+ */
+public class TraceRestTemplateCustomizerTest {
+
+    @Test
+    public void customize_arrayOutOfBound() {
+        final TraceRestTemplateCustomizer templateCustomizer = new TraceRestTemplateCustomizer(null);
+        final RestTemplate restTemplate = mock(RestTemplate.class);
+        when(restTemplate.getInterceptors()).thenReturn(new ArrayList<>());
+
+        templateCustomizer.customize(restTemplate);
+    }
+
+}


### PR DESCRIPTION
Beim Cutomizing des RestTemplates wird die richtig über das Stacktrace Array iteriert.